### PR TITLE
Update noir-ts-mode for latest tree-sitter-noir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      NOIR_TS_GRAMMAR_SOURCE: https://github.com/hhamud/tree-sitter-noir
+    steps:
+      - uses: actions/checkout@v4
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 29.4
+      - run: emacs --batch -Q -L . -L test -l test/noir-ts-mode-tests.el -f noir-ts-mode-test-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}
-        RECIPE: (noir-ts-mode :repo "hhamud/noir-ts-mode" :fetcher github)
+        RECIPE: (noir-ts-mode :fetcher github :repo "hhamud/noir-ts-mode")
       run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,22 @@ jobs:
       with:
         version: 28.2
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
       with:
-        python-version: "3.10"
+        enable-cache: true
     - name: Install
       run: |
-        python -m pip install --upgrade pip
+        uv python install 3.10
         git clone https://github.com/riscy/melpazoid.git ~/melpazoid
-        pip install ~/melpazoid
+        uv venv ~/melpazoid/.venv --python 3.10
+        . ~/melpazoid/.venv/bin/activate
+        uv pip install ~/melpazoid
     - name: Run
       env:
         LOCAL_REPO: ${{ github.workspace }}
         RECIPE: (noir-ts-mode :fetcher github :repo "hhamud/noir-ts-mode")
-      run: echo $GITHUB_REF && make -C ~/melpazoid
+      run: |
+        . ~/melpazoid/.venv/bin/activate
+        echo "$GITHUB_REF"
+        make -C ~/melpazoid

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ An Emacs tree-sitter mode for the Noir Language.
 ``` elisp
 (add-to-list
  'treesit-language-source-alist
- '(noir "https://github.com/hhamud/tree-sitter-noir.git"))
+ '(noir "https://github.com/hhamud/tree-sitter-noir" "main" "src"))
 ```
 
 3. Install the grammar
 ``` elisp
-M-x treesit-install-language-grammar 
+M-x treesit-install-language-grammar RET noir RET
 ```
 
 4. Check if it has installed successfully
@@ -27,17 +27,25 @@ M-x treesit-install-language-grammar
 
 5. Download `noir-ts-mode.el` from the [GitHub repository](https://github.com/hhamud/noir-ts-mode).
 
-6. Move `noir-mode.el` to a directory in your Emacs load path.
+6. Move `noir-ts-mode.el` to a directory in your Emacs load path.
 
 7. Add the following code to your Emacs configuration file:
 
 ```elisp
-(require noir-ts-mode)
+(require 'noir-ts-mode)
 ```
 
 ## Usage
 
 Once noir-ts-mode.el is installed, it will automatically be enabled when you open a .nr file. The major mode will provide syntax highlighting for editing Noir code.
+
+## Testing
+
+Run the ERT suite in batch Emacs with:
+
+```shell
+emacs --batch -Q -L . -L test -l test/noir-ts-mode-tests.el -f noir-ts-mode-test-run
+```
 
 ## Contributing
 

--- a/noir-ts-mode.el
+++ b/noir-ts-mode.el
@@ -75,10 +75,11 @@
   "Syntax table for `noir-ts-mode'.")
 
 (defvar noir-ts-mode--keywords
-  '("as" "else" "fn" "for" "if"
-    "impl" "in" "let" "mod" "global" "assert" "constrain"
-    "struct" "use" (crate) (super) (return) (self)
-    (mutable) (viewer)  (comptime))
+  '("as" "break" "continue" "else" "fn" "for" "if"
+    "impl" "in" "let" "loop" "mod" "global" "assert" "constrain"
+    "struct" "trait" "use" "where" "while"
+    (crate) (super) (return) (self)
+    (mutable) (viewer) (comptime) (unconstrained))
   "Noir keywords for tree-sitter font-locking.")
 
 (defvar noir-ts-mode--operators
@@ -89,84 +90,84 @@
 
 
 (defvar noir-ts-mode--font-lock-settings
-  (treesit-font-lock-rules
-
-   :feature 'bracket
-   :language 'noir
-   '((["(" ")" "[" "]" "{" "}"]) @font-lock-bracket-face)
-
-   :feature 'comment
-   :language 'noir
-   '((comment) @font-lock-comment-face)
-
-   :feature 'constant
-   :override t
-   :language 'noir
-   '((boolean) @font-lock-constant-face
-     (import_identifier (identifier) @font-lock-constant-face))
-
-
-   :feature 'delimiter
-   :language 'noir
-   '((["," "." ";" ":" "::"]) @font-lock-delimiter-face)
-
-   :feature 'keyword
-   :override t
-   :language 'noir
-   `([,@noir-ts-mode--keywords] @font-lock-keyword-face)
-
-   :feature 'number
-   :language 'noir
-   '((integer) @font-lock-constant-face)
-
-
-   :feature 'function-name
-   :language 'noir
-   '((function_definition
-      (identifier) @font-lock-function-name-face)
-     (function_call
-      (identifier) @font-lock-function-call-face))
-
-   :feature 'builtin
-   :override t
-   :language 'noir
-   '((macro) @font-lock-builtin-face)
-
-   :feature 'operator
-   :language 'noir
-   `([,@noir-ts-mode--operators] @font-lock-operator-face)
-
-
-   :feature 'type
-   :override t
-   :language 'noir
-   '(
-     (generic_type (identifier) @font-lock-type-face)
-     (generic (identifier) @font-lock-type-face)
-     (single_type) @font-lock-type-face
-     (array_type (identifier) @font-lock-type-face)
-     (module (identifier) @font-lock-type-face)
-     (return_type (identifier) @font-lock-type-face)
-     (struct_definition name: (identifier) @font-lock-type-face)
-     (struct_definition type: (identifier) @font-lock-type-face)
-     (typed_identifier type: (identifier) @font-lock-type-face)
-     (struct_method (identifier) @font-lock-type-face)
-     ((as_identifier type: (identifier) @font-lock-type-face)))
-
-
-   :feature 'variable
-   :language 'noir
-   '(
-     (let_declaration (binary_expression left: (identifier) @font-lock-variable-name-face))
-     (let_declaration (binary_expression left: (grouped_expression (identifier) @font-lock-variable-name-face)))
-     (struct_definition var: (identifier) @font-lock-variable-name-face)
-     (typed_identifier var: (identifier) @font-lock-variable-name-face)
-     (as_identifier (identifier) @font-lock-variable-name-face)
-     (global (binary_expression left: (typed_identifier var: (identifier) @font-lock-variable-name-face))))
-
-   :feature 'string
-   :language 'noir
-   '([(character) (string_literal)] @font-lock-string-face))
+  (append
+   (treesit-font-lock-rules
+    :feature 'bracket
+    :language 'noir
+    '((["(" ")" "[" "]" "{" "}"]) @font-lock-bracket-face))
+   (treesit-font-lock-rules
+    :feature 'comment
+    :language 'noir
+    '((comment) @font-lock-comment-face))
+   (treesit-font-lock-rules
+    :feature 'constant
+    :override t
+    :language 'noir
+    '((boolean) @font-lock-constant-face
+      (import_identifier (identifier) @font-lock-constant-face)))
+   (treesit-font-lock-rules
+    :feature 'delimiter
+    :language 'noir
+    '((["," "." ";" ":" "::"]) @font-lock-delimiter-face))
+   (treesit-font-lock-rules
+    :feature 'keyword
+    :override t
+    :language 'noir
+    `([,@noir-ts-mode--keywords] @font-lock-keyword-face))
+   (treesit-font-lock-rules
+    :feature 'number
+    :language 'noir
+    '([(integer) (float)] @font-lock-constant-face))
+   (treesit-font-lock-rules
+    :feature 'function-name
+    :language 'noir
+    '((function_definition
+       (identifier) @font-lock-function-name-face)
+      (trait_function_signature
+       (identifier) @font-lock-function-name-face)
+      (function_call
+       (identifier) @font-lock-function-call-face)))
+   (treesit-font-lock-rules
+    :feature 'builtin
+    :override t
+    :language 'noir
+    '((macro) @font-lock-builtin-face))
+   (treesit-font-lock-rules
+    :feature 'operator
+    :language 'noir
+    `([,@noir-ts-mode--operators] @font-lock-operator-face))
+   (treesit-font-lock-rules
+    :feature 'type
+    :override t
+    :language 'noir
+    '((generic_type (identifier) @font-lock-type-face)
+      (generic (identifier) @font-lock-type-face)
+      (single_type) @font-lock-type-face
+      (array_type (identifier) @font-lock-type-face)
+      (module (identifier) @font-lock-type-face)
+      (return_type (identifier) @font-lock-type-face)
+      (struct_definition name: (identifier) @font-lock-type-face)
+      (struct_definition type: (identifier) @font-lock-type-face)
+      (trait_definition (identifier) @font-lock-type-face)
+      (trait_alias (identifier) @font-lock-type-face)
+      (trait_bound type: (identifier) @font-lock-type-face)
+      (typed_identifier type: (identifier) @font-lock-type-face)
+      (as_identifier type: (identifier) @font-lock-type-face)))
+   (treesit-font-lock-rules
+    :feature 'variable
+    :language 'noir
+    '((let_declaration (identifier) @font-lock-variable-name-face)
+      (let_declaration (typed_identifier var: (identifier) @font-lock-variable-name-face))
+      (struct_definition var: (identifier) @font-lock-variable-name-face)
+      (typed_identifier var: (identifier) @font-lock-variable-name-face)
+      (parameter (identifier) @font-lock-variable-name-face)
+      (as_identifier (identifier) @font-lock-variable-name-face)
+      (global (identifier) @font-lock-variable-name-face)
+      (global (typed_identifier var: (identifier) @font-lock-variable-name-face))))
+   (treesit-font-lock-rules
+    :feature 'string
+    :language 'noir
+    '([(character) (string_literal)] @font-lock-string-face)))
 
   "Tree-sitter font-lock settings for `noir-ts-mode'.")
 
@@ -180,6 +181,7 @@
      ((parent-is "body") parent-bol noir-ts-mode-indent-offset)
      ((parent-is "_expression") parent-bol noir-ts-mode-indent-offset)
      ((parent-is "let_declaration") parent-bol noir-ts-mode-indent-offset)
+     ((parent-is "where_clause") parent-bol noir-ts-mode-indent-offset)
      ((parent-is "parameters") parent-bol noir-ts-mode-indent-offset)))
   "Tree-sitter indent rules for `noir-ts-mode'.")
 
@@ -219,7 +221,9 @@
   ;; Navigation.
   (setq-local treesit-defun-type-regexp
               (regexp-opt '("function_definition"
-                            "struct_method"
+                            "trait_function_signature"
+                            "trait_definition"
+                            "trait_alias"
                             "struct_definition")))
 
 

--- a/noir-ts-mode.el
+++ b/noir-ts-mode.el
@@ -1,10 +1,10 @@
-;;; noir-ts-mode.el --- tree-sitter support for Noir  -*- lexical-binding: t; -*-
+;;; noir-ts-mode.el --- Tree-sitter support for Noir  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) Hamza Hamud,
 
 ;; Version    : 0.0.1
 ;; Author     : Hamza Hamud <self@hamzahamud.com>
-;; Url        : https://github.com/hhamud/noir-ts-mode
+;; URL        : https://github.com/hhamud/noir-ts-mode
 ;; Maintainer : Hamza Hamud <self@hamzahamud.com>
 ;; Created    : July 2023
 ;; Keywords   : noir languages tree-sitter

--- a/test/noir-ts-mode-tests.el
+++ b/test/noir-ts-mode-tests.el
@@ -1,0 +1,214 @@
+;;; noir-ts-mode-tests.el --- Tests for noir-ts-mode  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; ERT tests for noir-ts-mode.
+
+;;; Code:
+
+(require 'ert)
+(require 'subr-x)
+(require 'treesit)
+(require 'noir-ts-mode)
+
+(defconst noir-ts-mode-test--repo-root
+  (expand-file-name ".." (file-name-directory (or load-file-name buffer-file-name)))
+  "Absolute path to the noir-ts-mode repository root.")
+
+(defconst noir-ts-mode-test--local-grammar-root
+  (expand-file-name "../tree-sitter-noir" noir-ts-mode-test--repo-root)
+  "Local sibling checkout of tree-sitter-noir, when available.")
+
+(defconst noir-ts-mode-test--remote-grammar-root
+  "https://github.com/hhamud/tree-sitter-noir"
+  "Fallback remote tree-sitter-noir repository for tests.")
+
+(defconst noir-ts-mode-test--simple-sample
+  "use crate::math::{double, SCALE};
+
+pub global N: u32 = 2;
+
+pub struct Point {
+    pub x: Field,
+    pub y: Field,
+}
+
+pub fn main(points: [Point; N]) -> Field {
+    let first = points[0];
+    double(first.x + SCALE)
+}
+
+mod math {
+    pub global SCALE: Field = 3;
+
+    pub fn double(x: Field) -> Field {
+        x + x
+    }
+}
+"
+  "Fixture covering global declarations, structs, modules, and functions.")
+
+(defconst noir-ts-mode-test--modern-sample
+  "#[deprecated(\"use fast_area\")]
+pub(crate) fn slow_area<T: Area>(shape: T) -> Field
+where
+    T: Area
+{
+    shape.area()
+}
+
+trait Area {
+    fn area(self) -> Field;
+}
+
+trait ShapeOps<T> = Area where T: Area;
+
+unconstrained fn control_flow(mut i: u32) {
+    let pi = 1.5;
+    while i < 10 {
+        i += 1;
+    }
+}
+"
+  "Fixture covering newer Noir syntax supported by tree-sitter-noir.")
+
+(defconst noir-ts-mode-test--indent-input
+  "pub(crate) fn slow_area<T: Area>(shape: T) -> Field
+where
+T: Area
+{
+shape.area()
+}
+
+unconstrained fn control_flow(mut i: u32) {
+while i < 10 {
+i += 1;
+}
+}
+"
+  "Unindented sample used for indentation tests.")
+
+(defconst noir-ts-mode-test--indent-expected
+  "pub(crate) fn slow_area<T: Area>(shape: T) -> Field
+where
+    T: Area
+{
+    shape.area()
+}
+
+unconstrained fn control_flow(mut i: u32) {
+    while i < 10 {
+        i += 1;
+    }
+}
+"
+  "Expected indentation for `noir-ts-mode-test--indent-input'.")
+
+(defun noir-ts-mode-test--grammar-source ()
+  "Return the grammar source to use for tests."
+  (or (getenv "NOIR_TS_GRAMMAR_SOURCE")
+      (and (file-directory-p noir-ts-mode-test--local-grammar-root)
+           noir-ts-mode-test--local-grammar-root)
+      noir-ts-mode-test--remote-grammar-root))
+
+(defun noir-ts-mode-test-ensure-grammar ()
+  "Install the Noir tree-sitter grammar for tests if needed."
+  (setq treesit-language-source-alist
+        `((noir ,(noir-ts-mode-test--grammar-source) "main" "src")))
+  (unless (treesit-ready-p 'noir)
+    (treesit-install-language-grammar 'noir)))
+
+(defmacro noir-ts-mode-test--with-buffer (contents &rest body)
+  "Create a temporary Noir buffer with CONTENTS and run BODY inside it."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (insert ,contents)
+     (setq-local buffer-file-name
+                 (expand-file-name "fixture.nr" temporary-file-directory))
+     (goto-char (point-min))
+     (noir-ts-mode)
+     (font-lock-ensure (point-min) (point-max))
+     ,@body))
+
+(defun noir-ts-mode-test--line-at-point ()
+  "Return the current line without its trailing newline."
+  (string-trim
+   (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+
+(defun noir-ts-mode-test--face-at-string (needle &optional occurrence)
+  "Return the `face' property at NEEDLE.
+If OCCURRENCE is non-nil, use the Nth occurrence of NEEDLE."
+  (let ((index (or occurrence 1)))
+    (save-excursion
+      (goto-char (point-min))
+      (dotimes (_ index)
+        (unless (search-forward needle nil t)
+          (ert-fail (format "Could not find %S in test buffer" needle))))
+      (get-text-property (match-beginning 0) 'face))))
+
+(defun noir-ts-mode-test--has-face-p (needle face &optional occurrence)
+  "Return non-nil if NEEDLE has FACE at OCCURRENCE."
+  (let ((actual (noir-ts-mode-test--face-at-string needle occurrence)))
+    (if (listp actual)
+        (memq face actual)
+      (eq face actual))))
+
+(ert-deftest noir-ts-mode-loads ()
+  (should (featurep 'noir-ts-mode)))
+
+(ert-deftest noir-ts-mode-auto-mode-detects-nr-files ()
+  (skip-unless (treesit-ready-p 'noir))
+  (with-temp-buffer
+    (setq-local buffer-file-name
+                (expand-file-name "sample.nr" temporary-file-directory))
+    (set-auto-mode)
+    (should (eq major-mode 'noir-ts-mode))
+    (should (treesit-parser-list))))
+
+(ert-deftest noir-ts-mode-font-locks-modern-noir-syntax ()
+  (skip-unless (treesit-ready-p 'noir))
+  (noir-ts-mode-test--with-buffer
+      (concat noir-ts-mode-test--simple-sample "\n" noir-ts-mode-test--modern-sample)
+    (should (noir-ts-mode-test--has-face-p "pub" 'font-lock-keyword-face 1))
+    (should (noir-ts-mode-test--has-face-p "global" 'font-lock-keyword-face 1))
+    (should (noir-ts-mode-test--has-face-p "trait" 'font-lock-keyword-face 1))
+    (should (noir-ts-mode-test--has-face-p "where" 'font-lock-keyword-face 1))
+    (should (noir-ts-mode-test--has-face-p "unconstrained" 'font-lock-keyword-face 1))
+    (should (noir-ts-mode-test--has-face-p "ShapeOps" 'font-lock-type-face 1))
+    (should (noir-ts-mode-test--has-face-p "slow_area" 'font-lock-function-name-face 1))
+    (should (noir-ts-mode-test--has-face-p "1.5" 'font-lock-constant-face 1))))
+
+(ert-deftest noir-ts-mode-indents-modern-noir-syntax ()
+  (skip-unless (treesit-ready-p 'noir))
+  (noir-ts-mode-test--with-buffer noir-ts-mode-test--indent-input
+    (indent-region (point-min) (point-max))
+    (should (equal (buffer-string) noir-ts-mode-test--indent-expected))))
+
+(ert-deftest noir-ts-mode-beginning-of-defun-handles-new-definition-kinds ()
+  (skip-unless (treesit-ready-p 'noir))
+  (noir-ts-mode-test--with-buffer noir-ts-mode-test--modern-sample
+    (search-forward "shape.area()")
+    (beginning-of-defun)
+    (should (equal (noir-ts-mode-test--line-at-point)
+                   "pub(crate) fn slow_area<T: Area>(shape: T) -> Field"))
+
+    (goto-char (point-min))
+    (search-forward "fn area(self) -> Field;")
+    (beginning-of-defun)
+    (should (equal (noir-ts-mode-test--line-at-point)
+                   "fn area(self) -> Field;"))
+
+    (goto-char (point-min))
+    (search-forward "let pi = 1.5;")
+    (beginning-of-defun)
+    (should (equal (noir-ts-mode-test--line-at-point)
+                   "unconstrained fn control_flow(mut i: u32) {"))))
+
+(defun noir-ts-mode-test-run ()
+  "Install the Noir grammar if needed and run the ERT suite."
+  (interactive)
+  (noir-ts-mode-test-ensure-grammar)
+  (ert-run-tests-batch-and-exit))
+
+(provide 'noir-ts-mode-tests)
+
+;;; noir-ts-mode-tests.el ends here


### PR DESCRIPTION
## Summary
- align `noir-ts-mode` with the current `tree-sitter-noir` grammar, including newer Noir syntax and definition kinds
- update the README install instructions to match the current parser repository layout
- add a batch ERT suite and GitHub Actions workflow for mode loading, font-lock, indentation, and defun navigation

## Verification
- emacs --batch -Q -L . -L test -l test/noir-ts-mode-tests.el -f noir-ts-mode-test-run
